### PR TITLE
Interpret run as interval instead of warmup

### DIFF
--- a/garmin_planner/main.py
+++ b/garmin_planner/main.py
@@ -42,7 +42,7 @@ def createWorkoutStep(step: dict, stepCount: list):
         parsedStep, numIteration = parse_bracket(stepName)
         match parsedStep:
             case "run":
-                stepType = StepType.WARMUP
+                stepType = StepType.INTERVAL
             case "warmup":
                 stepType = StepType.WARMUP
             case "cooldown":


### PR DESCRIPTION
Changes run step type to be treated as INTERVAL instead of WARMUP, so Garmin displays these steps correctly in structured workouts.